### PR TITLE
Fallback to turing network if goldberg is selected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ wget --https-only --secure-protocol=TLSv1_2 --quiet -O - avail.sh | bash
 ```
 You can pass additional flags to the script like:
 ```bash
-curl -sL1 avail.sh | bash -s -- --network goldberg
+curl -sL1 avail.sh | bash -s -- --network turing
 ```
 
 Currently available flags are:
-* `network`: can be one of the following: [`goldberg`, `local`]
+* `network`: can be one of the following: [`turing`, `local`]
 * `config`: path to the configuration file, availup will generate a config if this flag is not specified
   * This flag is always required when running a local testnet
 * `identity`: path to the identity file, availup will generate a config if this flag is not specified
@@ -58,7 +58,7 @@ curl -sL1 avail.sh | bash -s -- --identity ~/identity.toml
 
 Alternatively, you can pass a specific application ID with `availup`:
 ```bash
-rm ~/.avail/goldberg/config.yml
+rm ~/.avail/turing/config.yml
 # and rerunning the script with flags:
 curl -sL1 avail.sh | bash -s -- --app_id 1
 ```

--- a/availup.sh
+++ b/availup.sh
@@ -53,7 +53,18 @@ if [ -z "$network" ]; then
 else
     NETWORK="$network"
 fi
-GOLDBERG_CONFIG_PARAMS="bootstraps=['/dns/bootnode.2.lightclient.goldberg.avail.tools/tcp/37000/p2p/12D3KooWRCgfvaLSnQfkwGehrhSNpY7i5RenWKL2ARst6ZqgdZZd']\nfull_node_ws=['wss://rpc-goldberg.sandbox.avail.tools:443','wss://avail-goldberg.public.blastapi.io:443','wss://lc-rpc-goldberg.avail.tools:443/ws','wss://avail2.polkadotters.com:443/ws']\nconfidence=80.0\navail_path='$HOME/.avail/$NETWORK/data'\nkad_record_ttl=43200\not_collector_endpoint='http://otelcol.lightclient.goldberg.avail.tools:4317'\ngenesis_hash='6f09966420b2608d1947ccfb0f2a362450d1fc7fd902c29b67c906eaa965a7ae'\n"
+
+UPGRADE=0
+if [ "$NETWORK" = "turing" ]; then
+    echo "📌 Turing testnet selected."
+elif [ "$NETWORK" = "goldberg" ]; then
+    echo "📌 Goldberg network is deprecated. Turing testnet selected."
+    NETWORK="turing"
+    UPGRADE=1
+elif [ "$NETWORK" = "local" ]; then
+    echo "📌 Local testnet selected."
+fi
+
 TURING_CONFIG_PARAMS="bootstraps=['/dns/bootnode.1.lightclient.turing.avail.so/tcp/37000/p2p/12D3KooWBkLsNGaD3SpMaRWtAmWVuiZg1afdNSPbtJ8M8r9ArGRT']\nfull_node_ws=['wss://avail-turing.public.blastapi.io','wss://turing-testnet.avail-rpc.com']\nconfidence=80.0\navail_path='$HOME/.avail/$NETWORK/data'\nkad_record_ttl=43200\not_collector_endpoint='http://otel.lightclient.turing.avail.so:4317'\ngenesis_hash='d3d2f3a3495dc597434a99d7d449ebad6616db45e4e4f178f31cc6fa14378b70'\n"
 AVAIL_BIN=$HOME/.avail/$NETWORK/bin/avail-light
 if [ ! -d "$HOME/.avail/$NETWORK" ]; then
@@ -68,9 +79,14 @@ fi
 if [ ! -d "$HOME/.avail/$NETWORK/config" ]; then
     mkdir $HOME/.avail/$NETWORK/config
 fi
+
+readonly TURING_VERSION="v1.9.0"
+readonly LOCAL_VERSION="v1.9.0"
+
+
+
 if [ "$NETWORK" = "turing" ]; then
-    echo "📌 Turing testnet selected."
-    VERSION="v1.8.1"
+    VERSION=$TURING_VERSION
     if [ -z "$config" ]; then
         CONFIG="$HOME/.avail/$NETWORK/config/config.yml"
         if [ -f "$CONFIG" ]; then
@@ -84,31 +100,15 @@ if [ "$NETWORK" = "turing" ]; then
     else
         CONFIG="$config"
     fi
-elif [ "$NETWORK" = "goldberg" ]; then
-    echo "📌 Goldberg testnet selected."
-    VERSION="v1.7.11"
-    if [ -z "$config" ]; then
-        CONFIG="$HOME/.avail/$NETWORK/config/config.yml"
-        if [ -f "$CONFIG" ]; then
-            echo "🗑️  Wiping old config file at $CONFIG."
-            rm $CONFIG
-        else
-            echo "🤷 No configuration file set. This will be automatically generated at startup."
-        fi
-        touch $CONFIG
-        echo -e $GOLDBERG_CONFIG_PARAMS >>$CONFIG
-    else
-        CONFIG="$config"
-    fi
 elif [ "$NETWORK" = "local" ]; then
     echo "📌 Local testnet selected."
-    VERSION="v1.7.11"
+    VERSION=$LOCAL_VERSION
     if [ -z "$config" ]; then
         echo "🚫 No configuration file was provided for local testnet, exiting."
         exit 1
     fi
 else
-    echo "🚫 Invalid network selected. Select one of the following: goldberg, local."
+    echo "🚫 Invalid network selected. Select one of the following: turing, local."
     exit 1
 fi
 if [ -z "$app_id" ]; then
@@ -134,18 +134,19 @@ if uname -r | grep -qEi "(Microsoft|WSL)"; then
         mkdir $HOME/.avail/$NETWORK/data
     fi
     if [ "$force_wsl" != 'y' -a "$force_wsl" != 'yes' ]; then
-        echo "👀 WSL detected. This script is not fully compatible with WSL. Please download the Windows runner instead by clicking this link: https://github.com/availproject/avail-light/releases/download/v1.7.10/avail-light-windows-runner.zip Alternatively, rerun the command with --force_wsl y"
+        echo "👀 WSL detected. This script is not fully compatible with WSL. Please download the Windows runner instead by clicking this link: https://github.com/availproject/avail-light/releases/download/$VERSION/avail-light-windows-runner.zip Alternatively, rerun the command with --force_wsl y"
         exit 1
     else
         echo "👀 WSL detected. The binary is not fully compatible with WSL but forcing the run anyway."
     fi
 fi
+
 # check if avail-light version matches!
-UPGRADE=0
-if [ ! -z "$upgrade" ] || [ "$NETWORK" = "goldberg" ]; then
+if [ ! -z "$upgrade" ] || [ "$UPGRADE" = 1 ]; then
     echo "🔄 Checking for updates..."
     if [ -f $AVAIL_BIN ]; then
         CURRENT_VERSION="v$($HOME/.avail/$NETWORK/bin/avail-light --version | cut -d " " -f 2)"
+
         if [ "$CURRENT_VERSION" != "$VERSION" ]; then
             UPGRADE=1
             echo "⬆️  Avail binary is out of date. Upgrading..."
@@ -159,7 +160,7 @@ if [ ! -z "$upgrade" ] || [ "$NETWORK" = "goldberg" ]; then
 else
     if [ -f $AVAIL_BIN ]; then
         CURRENT_VERSION="v$($HOME/.avail/$NETWORK/bin/avail-light --version | cut -d " " -f 2)"
-        if [ "$CURRENT_VERSION" = "v1.7.11" ]; then
+        if [ "$CURRENT_VERSION" = "$LOCAL_VERSION" ]; then
             UPGRADE=1
             echo "⬆️  Avail binary is out of date. Upgrading..."
         fi
@@ -202,8 +203,6 @@ if [ "$UPGRADE" = 1 ]; then
             touch $CONFIG
             if [ "$NETWORK" = "turing" ]; then
                 echo -e $TURING_CONFIG_PARAMS >>$CONFIG
-            elif [ "$NETWORK" = "goldberg" ]; then
-                echo -e $GOLDBERG_CONFIG_PARAMS >>$CONFIG
             fi
         fi
         if [ -d "$HOME/.avail/$NETWORK/data" ]; then


### PR DESCRIPTION
This PR deprecates goldberg network, and fallbacks to turing. Since turing folders will be used, there is no need to clean up the state. It also introduces readonly variables for turing and local versions. Clients that uses --network golberg parameter will be always updated.

This PR should be merged once version 1.9.0 is released.
