### PR TITLE
fix: sophon otel config

### DIFF
--- a/configs/sophon.yml
+++ b/configs/sophon.yml
@@ -1,6 +1,7 @@
+project_name='sophon'
 bootstraps=['/dns/bootnode.1.lightclient.mainnet.avail.so/tcp/37000/p2p/12D3KooW9x9qnoXhkHAjdNFu92kMvBRSiFBMAoC5NnifgzXjsuiM']
 full_node_ws=['wss://mainnet-rpc.avail.so/ws','wss://mainnet.avail-rpc.com','wss://avail-mainnet.public.blastapi.io']
 confidence=80.0
 kad_record_ttl=43200
 genesis_hash='b91746b45e0346cc2f815a520b9c6cb4d5c0902af848db0a80f85932d2e8276a'
-ot_collector_endpoint='http://otel.lightclient.mainnet.avail.so:4317'
+ot_collector_endpoint='http://otel.lightclient.sophon.avail.so:4317'


### PR DESCRIPTION
# Changes
- [x] Fixes sophon otel config
- [x] Adds sophon project name


## Reason for Change
Customize sophon metrics:
- `sophon_light_starts_total`
- `sophon_light_up_total`

```rust
# HELP sophon_light_starts_total 
# TYPE sophon_light_starts_total counter
sophon_light_starts_total{avail_address="1002e7b4ee842d8f94c5da76dc82dba59af223b7b0715467bb1770a208a26451",basedn="sophon.lightclient",client_alias="",client_id="f000ccd0-d058-4b04-b253-d20cba3341a1",execution_id="98d01bf2-08a3-4b2a-b774-da87c8663722",job="unknown_service",multiaddress="",network="mainnet:b91746",operating_mode="client",peerID="12D3KooWRN6JZucanLQpWSHam1WnVGmWP722UAyd4cFHdfvakogd",role="lightnode",service_name="unknown_service",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="0.24.1",version="1.12.1"} 1
# HELP sophon_light_up_total 
# TYPE sophon_light_up_total counter
sophon_light_up_total{avail_address="1002e7b4ee842d8f94c5da76dc82dba59af223b7b0715467bb1770a208a26451",basedn="sophon.lightclient",client_alias="",client_id="f000ccd0-d058-4b04-b253-d20cba3341a1",execution_id="98d01bf2-08a3-4b2a-b774-da87c8663722",job="unknown_service",multiaddress="/ip4/172.17.0.3/tcp/37000/p2p/12D3KooWRN6JZucanLQpWSHam1WnVGmWP722UAyd4cFHdfvakogd",network="mainnet:b91746",operating_mode="client",peerID="12D3KooWRN6JZucanLQpWSHam1WnVGmWP722UAyd4cFHdfvakogd",role="lightnode",service_name="unknown_service",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="0.24.1",version="1.12.1"} 1
```