### PR TITLE
fix: temp remove broken rpc

### DIFF
--- a/configs/sophon.yml
+++ b/configs/sophon.yml
@@ -1,5 +1,5 @@
 project_name='sophon'
 bootstraps=['/dns/bootnode.1.lightclient.mainnet.avail.so/tcp/37000/p2p/12D3KooW9x9qnoXhkHAjdNFu92kMvBRSiFBMAoC5NnifgzXjsuiM']
-full_node_ws=['wss://mainnet.avail-rpc.com','wss://avail-mainnet.public.blastapi.io', 'wss://avail-us.brightlystake.com', 'wss://avail-rpc.publicnode.com']
+full_node_ws=['wss://mainnet.avail-rpc.com','wss://avail-mainnet.public.blastapi.io', 'wss://avail.api.onfinality.io/public-ws', 'wss://avail-us.brightlystake.com', 'wss://avail-rpc.publicnode.com']
 genesis_hash='b91746b45e0346cc2f815a520b9c6cb4d5c0902af848db0a80f85932d2e8276a'
 ot_collector_endpoint='http://otel.lightclient.sophon.avail.so:4317'

--- a/configs/sophon.yml
+++ b/configs/sophon.yml
@@ -1,5 +1,5 @@
 project_name='sophon'
 bootstraps=['/dns/bootnode.1.lightclient.mainnet.avail.so/tcp/37000/p2p/12D3KooW9x9qnoXhkHAjdNFu92kMvBRSiFBMAoC5NnifgzXjsuiM']
-full_node_ws=['wss://mainnet.avail-rpc.com','wss://avail-mainnet.public.blastapi.io', 'wss://avail.api.onfinality.io/ws?apikey=13f13c3f-28e8-4120-bf7f-12fd20686907', 'wss://avail-us.brightlystake.com', 'wss://avail-rpc.publicnode.com']
+full_node_ws=['wss://mainnet.avail-rpc.com','wss://avail-mainnet.public.blastapi.io', 'wss://avail-us.brightlystake.com', 'wss://avail-rpc.publicnode.com']
 genesis_hash='b91746b45e0346cc2f815a520b9c6cb4d5c0902af848db0a80f85932d2e8276a'
 ot_collector_endpoint='http://otel.lightclient.sophon.avail.so:4317'


### PR DESCRIPTION
# Problem Statement

Currently Onfinality endpoint has some auth endpoint issues and it also still uses an apikey query param which is suboptimal.

Until we fix the endpoint itself let's remove it from config to reduce unnecessary RPC call retries on LC side.

```MD
Error: Unexpected server response: 401
Handshake Details
Request Method: GET
Status Code: 401 Unauthorized
Request Headers
Sec-WebSocket-Version: 13
Sec-WebSocket-Key: frxm1WCNwrj0go56pgk0qQ==
Connection: Upgrade
Upgrade: websocket
Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
Host: avail.api.onfinality.io
Response Headers
Date: Tue, 10 Dec 2024 11:55:55 GMT
Content-Type: application/json; charset=utf-8
Connection: keep-alive
Content-Length: 52
X-Continent: AS
X-Cluster: hk
X-Kong-Response-Latency: 2
Online
```