### PR TITLE
fix: fail config parse

### DIFF
--- a/availup.sh
+++ b/availup.sh
@@ -103,10 +103,10 @@ if [ "$NETWORK" = "mainnet" ]; then
             echo "📥 Downloading configuration file from $config_url..."
             if command -v curl >/dev/null 2>&1; then
                 curl -sL $config_url >>$CONFIG
-                echo -e "avail_path='$HOME/.avail/$NETWORK/data'\n" >>$CONFIG
+                echo -e "\navail_path='$HOME/.avail/$NETWORK/data'\n" >>$CONFIG
             elif command -v wget >/dev/null 2>&1; then
                 wget -qO- $config_url >>$CONFIG
-                echo -e "avail_path='$HOME/.avail/$NETWORK/data'\n" >>$CONFIG
+                echo -e "\navail_path='$HOME/.avail/$NETWORK/data'\n" >>$CONFIG
             else
                 echo "🚫 Neither curl nor wget are available. Please install one of these and try again."
                 exit 1


### PR DESCRIPTION
# Changes
- [x] Adds a new line before `avail_path` concat

## Reason for change
Current availup script breaks due to a failed TOML parsing while using `--config_url` flag

e.g:

```
╰─$ curl -fsSL https://avail.sh | bash -s -- --config_url https://raw.githubusercontent.com/example/repo/config.yml
🆙 Starting Availup...
🗑️ Wiping old config file at ~/.avail/mainnet/config/config.yml.
📥 Downloading configuration file from https://raw.githubusercontent.com/example/repo/config.yml...
📲 No app ID specified. Defaulting to light client mode.
⬆️ Triggering default upgrade of Avail binary...
🗑️ Wiping state data...
✅ Availup exited successfully.
🧱 Starting Avail.
Error: Failed to load configuration from ~/.avail/mainnet/config/config.yml

Caused by:
    Bad TOML data: expected newline, found an identifier at line 17 column 43

Location:
    client/src/main.rs:354:14
```